### PR TITLE
Add the Maven project to EcorePlugin's PlatformResourceMap

### DIFF
--- a/org.eclipse.xtext.maven.plugin/src/test/java/org/eclipse/xtext/maven/plugin/XtextGeneratorIT.java
+++ b/org.eclipse.xtext.maven.plugin/src/test/java/org/eclipse/xtext/maven/plugin/XtextGeneratorIT.java
@@ -113,6 +113,7 @@ public class XtextGeneratorIT {
 				verifier.getBasedir() + "/target/xtext-temp/classes/org/eclipse/xcoretest/MyClass2.class");
 		verifier.assertFileMatches(verifier.getBasedir() + "/src-gen/org/eclipse/xcoretest/MyEnum.java",
 				"(?s).*MY_FIRST_LITERAL\\(-7.*MY_SECOND_LITERAL\\(137.*");
+		verifier.assertFilePresent(verifier.getBasedir() + "/target/classes/model/Funny.ecore");
 	}
 
 	@Test

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/xcore-lang/model/Funny.xcore
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/xcore-lang/model/Funny.xcore
@@ -1,4 +1,5 @@
-@GenModel(modelDirectory="./src-gen")
+@GenModel(modelDirectory="./src-gen",
+    publicationLocation="/xcore-lang/target/classes/model/Funny.ecore")
 
 package org.eclipse.xcoretest
 


### PR DESCRIPTION
This will fix #26.

I'm not able to test my changes however, because not a single integration test works on my machine. I did: 
```
$ mvn -PuseSonatypeSnapshots install
…
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on
Running org.eclipse.xtext.maven.plugin.XtextGeneratorIT
Tests run: 9, Failures: 0, Errors: 9, Skipped: 0, Time elapsed: 87.419 sec <<< FAILURE!

Results :

Tests in error: 
  simpleLang(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  mavenConfiguration(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  purexbase(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  clustering(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  outputPerSource(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  javaLangBiRef(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  aggregation(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  xcore(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 
  bug463946(org.eclipse.xtext.maven.plugin.XtextGeneratorIT): Exit code was non-zero: 1; command line and log = 

Tests run: 9, Failures: 0, Errors: 9, Skipped: 0
```
