### PR TITLE
Make the plugin thread-safe

### DIFF
--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextGenerator.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextGenerator.java
@@ -34,8 +34,14 @@ import com.google.inject.Injector;
  * @goal generate
  * @phase generate-sources
  * @requiresDependencyResolution compile
+ * @threadSafe true
  */
 public class XtextGenerator extends AbstractMojo {
+    
+	/**
+	 * Lock object to ensure thread-safety
+	 */
+	private static final Object lock = new Object();
 
 	/**
 	 * Location of the generated source files.
@@ -137,9 +143,11 @@ public class XtextGenerator extends AbstractMojo {
 		if (skip) {
 			getLog().info("skipped.");
 		} else {
-			new MavenLog4JConfigurator().configureLog4j(getLog());
-			configureDefaults();
-			internalExecute();
+			synchronized(lock) {
+				new MavenLog4JConfigurator().configureLog4j(getLog());
+				configureDefaults();
+				internalExecute();
+			}
 		}
 	}
 


### PR DESCRIPTION
A very simple approach for thread-safety: Run everything sequentially instead of producing wrong results in multi-thread build. Could probably be optimized further, but this PR is a very quick & reliable solution to ensure thread-safety as suggested by [the maven docs](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) (section: "Mojo thread safety assertion checklist").

See also issue #36.

Signed-off-by: Patrick Fink <mail@pfink.de>