### PR TITLE
[eclipse/xtext#1224] Detect local Jenkins environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node {
 		def workspace = pwd()
 		def mvnHome = tool 'M3'
 		env.M2_HOME = "${mvnHome}"
-		sh "${mvnHome}/bin/mvn --batch-mode --update-snapshots -fae -PuseJenkinsSnapshots -Dmaven.test.failure.ignore=true -Dmaven.repo.local=${workspace}/.m2/repository -f org.eclipse.xtext.maven.parent/pom.xml -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean deploy"
+		sh "${mvnHome}/bin/mvn --batch-mode --update-snapshots -fae -PuseJenkinsSnapshots -DJENKINS_URL=$JENKINS_URL -Dmaven.test.failure.ignore=true -Dmaven.repo.local=${workspace}/.m2/repository -DJENKINS_URL=$JENKINS_URL -f org.eclipse.xtext.maven.parent/pom.xml -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean deploy"
 		step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/*.xml'])
 	}
 	

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -23,6 +23,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<branch_url_segment>master</branch_url_segment>
+		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
 	</properties>
 
 	<modules>
@@ -239,19 +240,19 @@
 			<repositories>
 				<repository>
 					<id>lsp4j-from-jenkins</id>
-					<url>http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 				<repository>
 					<id>xtext-lib-from-jenkins</id>
-					<url>http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 				<repository>
 					<id>xtext-core-from-jenkins</id>
-					<url>http://services.typefox.io/open-source/jenkins/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 				<repository>
 					<id>xtext-extras-from-jenkins</id>
-					<url>http://services.typefox.io/open-source/jenkins/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 			</repositories>
 		</profile>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -8,23 +8,24 @@
 	<packaging>pom</packaging>
 	<properties>
 		<branch_url_segment>master</branch_url_segment>
+		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
 	</properties>
 	<repositories>
 		<repository>
 			<id>lsp4j-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>xtext-lib-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>xtext-core-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>xtext-extras-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>central snapshots</id>
@@ -44,19 +45,19 @@
 	<pluginRepositories>
 		<pluginRepository>
 			<id>lsp4j-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/lsp4j/job/master/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>xtext-lib-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>xtext-core-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>xtext-extras-from-jenkins</id>
-			<url>http://services.typefox.io/open-source/jenkins/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>central snapshots</id>


### PR DESCRIPTION
Build steps defined in Jenkinsfile pass the built-in environment variable 'JENKINS_URL' to the Gradle/Maven executions. This is evaluated in the build scripts for upstream repository URLs. On Xtext JIPP this will use upstream repos from JIPP. In local builds outside of Jenkins the property defaults to Typefox CI like before.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>