### PR TITLE
[eclipse/xtext-umbrella#65] Adjust upstream branch

### DIFF
--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -22,7 +22,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-		<branch_url_segment>master</branch_url_segment>
+		<upstreamBranch>master</upstreamBranch>
 		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
 	</properties>
 
@@ -244,15 +244,15 @@
 				</repository>
 				<repository>
 					<id>xtext-lib-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 				<repository>
 					<id>xtext-core-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 				<repository>
 					<id>xtext-extras-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+					<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 				</repository>
 			</repositories>
 		</profile>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -7,7 +7,7 @@
 	<artifactId>xtext-maven-plugin-it</artifactId>
 	<packaging>pom</packaging>
 	<properties>
-		<branch_url_segment>master</branch_url_segment>
+		<upstreamBranch>master</upstreamBranch>
 		<JENKINS_URL>http://services.typefox.io/open-source/jenkins</JENKINS_URL>
 	</properties>
 	<repositories>
@@ -17,15 +17,15 @@
 		</repository>
 		<repository>
 			<id>xtext-lib-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>xtext-core-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>xtext-extras-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
 			<id>central snapshots</id>
@@ -49,15 +49,15 @@
 		</pluginRepository>
 		<pluginRepository>
 			<id>xtext-lib-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-lib/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>xtext-core-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-core/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>xtext-extras-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-extras/job/${branch_url_segment}/lastStableBuild/artifact/build/maven-repository/</url>
+			<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>central snapshots</id>


### PR DESCRIPTION
Renamed pom property ‚branch_url_segment‘ to ‚upstreamBranch‘ to align it with upstream-repositories.gradle

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>