### PR TITLE
[#62] added outputconfiguration.setName to allow configuration of nondefault outputs

### DIFF
--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/OutputConfiguration.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/OutputConfiguration.java
@@ -119,6 +119,10 @@ public class OutputConfiguration {
 		return name;
 	}
 
+	public void setName(String name) {
+		this.name = name;
+	}
+
 	public String getDescription() {
 		return description;
 	}


### PR DESCRIPTION
[#62] added outputconfiguration.setName to allow configuration of nondefault outputs

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>