### PR TITLE
[eclipse/xtext-maven#38] Switch to annotations instead of doclet

### DIFF
--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -104,44 +104,6 @@
 				</executions>
 				<configuration>
 					<additionalOptions>${maven.javadoc.opts}</additionalOptions>
-					<!-- Maven tags used in XtextGenerator Javadoc -->
-					<tags>
-						<tag>
-							<name>goal</name>
-							<placement>a</placement>
-							<head>Goal:</head>
-						</tag>
-						<tag>
-							<name>phase</name>
-							<placement>a</placement>
-							<head>Phase:</head>
-						</tag>
-						<tag>
-							<name>threadSafe</name>
-							<placement>a</placement>
-							<head>Thread Safe:</head>
-						</tag>
-						<tag>
-							<name>parameter</name>
-							<placement>a</placement>
-							<head>Parameter:</head>
-						</tag>
-						<tag>
-							<name>required</name>
-							<placement>a</placement>
-							<head>Required:</head>
-						</tag>
-						<tag>
-							<name>requiresDependencyResolution</name>
-							<placement>a</placement>
-							<head>Requires Dependency Resolution:</head>
-						</tag>
-						<tag>
-							<name>readonly</name>
-							<placement>a</placement>
-							<head>Read Only:</head>
-						</tag>
-					</tags>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/org.eclipse.xtext.maven.plugin/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/pom.xml
@@ -42,6 +42,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>${maven.version}</version>
+			<scope>provided</scope>
+		</dependency>    
+		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext.builder.standalone</artifactId>
 			<version>${project.version}</version>


### PR DESCRIPTION
Replace the special maven javadoc annotations to describe the api of
this plugin with real maven annotations.

Signed-off-by: Jan Rosczak <jan.rosczak@web.de>