### PR TITLE
[eclipse/xtext#1424] Change default Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This repository contains the [Maven plug-in for Xtext](https://www.eclipse.org/X
 
 Checkout and run `mvn clean install -PuseSonatypeSnapshots`.
 
-With the above configuration, [Sonatype snapshots](https://oss.sonatype.org/content/repositories/snapshots) are used for upstream Xtext dependencies. The alternative profile `-PuseJenkinsSnapshots` activates the Maven repositories generated on the [Jenkins server](https://services.typefox.io/open-source/jenkins/) for [xtext-lib](https://github.com/eclipse/xtext-lib), [xtext-core](https://github.com/eclipse/xtext-core), and [xtext-extras](https://github.com/eclipse/xtext-extras) instead.
+With the above configuration, [Sonatype snapshots](https://oss.sonatype.org/content/repositories/snapshots) are used for upstream Xtext dependencies. The alternative profile `-PuseJenkinsSnapshots` activates the Maven repositories generated on the [Jenkins server](https://ci.eclipse.org/xtext/) for [xtext-lib](https://github.com/eclipse/xtext-lib), [xtext-core](https://github.com/eclipse/xtext-core), and [xtext-extras](https://github.com/eclipse/xtext-extras) instead.
 
 ## Continuous Integration
 
-This project is built by the [xtext-maven multi-branch job on Jenkins](https://services.typefox.io/open-source/jenkins/job/xtext-maven/).
+This project is built by the [xtext-maven multi-branch job on Jenkins](https://ci.eclipse.org/xtext/job/xtext-maven/).

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -21,7 +21,7 @@
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<maven.javadoc.opts></maven.javadoc.opts>
 		<upstreamBranch>master</upstreamBranch>
-		<JENKINS_URL>https://services.typefox.io/open-source/jenkins</JENKINS_URL>
+		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 	</properties>
 
 	<dependencyManagement>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>pom</packaging>
 	<properties>
 		<upstreamBranch>master</upstreamBranch>
-		<JENKINS_URL>https://services.typefox.io/open-source/jenkins</JENKINS_URL>
+		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Use https://ci.eclipse.org/xtext as default Jenkins URL

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>