### PR TITLE
update to guava 27.1

### DIFF
--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -20,7 +20,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<maven.javadoc.opts></maven.javadoc.opts>
-		<upstreamBranch>master</upstreamBranch>
+		<upstreamBranch>cd_guava271</upstreamBranch>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 	</properties>
 

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -8,7 +8,7 @@
 	<version>IT-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
-		<upstreamBranch>master</upstreamBranch>
+		<upstreamBranch>cd_guava271</upstreamBranch>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Fixes eclipse/xtext#1398 and eclipse/xtext-lib#111

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>