### PR TITLE
[eclipse/xtext#1561] removed superfluous timestamps() config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,6 @@ spec:
     buildDiscarder(logRotator(numToKeepStr:'15'))
     disableConcurrentBuilds()
     timeout(time: 60, unit: 'MINUTES')
-    timestamps()
   }
   
   stages {


### PR DESCRIPTION
[eclipse/xtext#1561] removed superfluous timestamps() config
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>