### PR TITLE
Small changes to xtext-maven-plugin

### DIFF
--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/MavenLog4JConfigurator.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/MavenLog4JConfigurator.java
@@ -48,14 +48,28 @@ public class MavenLog4JConfigurator {
 				if (event.getMessage() == null) {
 					return;
 				}
-				if (Level.DEBUG == event.getLevel()) {
-					log.debug((CharSequence) event.getMessage(), getThrowable(event));
-				} else if (Level.INFO == event.getLevel()) {
-					log.info((CharSequence) event.getMessage(), getThrowable(event));
-				} else if (Level.WARN == event.getLevel()) {
-					log.warn((CharSequence) event.getMessage(), getThrowable(event));
-				} else if (Level.ERROR == event.getLevel()) {
-					log.error((CharSequence) event.getMessage(), getThrowable(event));
+				Throwable throwable = getThrowable(event);
+				if (throwable != null) {
+					// Log4j throws a NullPointerException if throwable is null
+					if (Level.DEBUG == event.getLevel()) {
+						log.debug((CharSequence) event.getMessage(), throwable);
+					} else if (Level.INFO == event.getLevel()) {
+						log.info((CharSequence) event.getMessage(), throwable);
+					} else if (Level.WARN == event.getLevel()) {
+						log.warn((CharSequence) event.getMessage(), throwable);
+					} else if (Level.ERROR == event.getLevel()) {
+						log.error((CharSequence) event.getMessage(), throwable);
+					}
+				} else {
+					if (Level.DEBUG == event.getLevel()) {
+						log.debug((CharSequence) event.getMessage());
+					} else if (Level.INFO == event.getLevel()) {
+						log.info((CharSequence) event.getMessage());
+					} else if (Level.WARN == event.getLevel()) {
+						log.warn((CharSequence) event.getMessage());
+					} else if (Level.ERROR == event.getLevel()) {
+						log.error((CharSequence) event.getMessage());
+					}
 				}
 			}
 

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/MavenLog4JConfigurator.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/MavenLog4JConfigurator.java
@@ -50,7 +50,9 @@ public class MavenLog4JConfigurator {
 				}
 				Throwable throwable = getThrowable(event);
 				if (throwable != null) {
-					// Log4j throws a NullPointerException if throwable is null
+					// Loggers like org.apache.maven.plugin.logging.SystemStreamLog
+					// (used by Maven Testing Harness)
+					// throw a NullPointerException if throwable is null
 					if (Level.DEBUG == event.getLevel()) {
 						log.debug((CharSequence) event.getMessage(), throwable);
 					} else if (Level.INFO == event.getLevel()) {

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextGenerator.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextGenerator.java
@@ -30,7 +30,6 @@ import org.eclipse.xtext.util.Strings;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
@@ -74,7 +73,7 @@ public class XtextGenerator extends AbstractMojo {
 	 * The default value is a reference to the project's ${project.compileSourceRoots}.<br>
 	 * When adding a new entry the default value will be overwritten not extended.
 	 */
-	@Parameter
+	@Parameter(defaultValue = "${project.compileSourceRoots}", required = true)
 	private List<String> sourceRoots;
 
 	/**
@@ -83,7 +82,7 @@ public class XtextGenerator extends AbstractMojo {
 	 * When adding a new entry the default value will be overwritten not extended.<br>
 	 * Used when your language needs java.
 	 */
-	@Parameter
+	@Parameter(defaultValue = "${project.compileSourceRoots}", required = true)
 	private List<String> javaSourceRoots;
 
 	@Parameter(required = true)
@@ -155,7 +154,6 @@ public class XtextGenerator extends AbstractMojo {
 		} else {
 			synchronized (lock) {
 				new MavenLog4JConfigurator().configureLog4j(getLog());
-				configureDefaults();
 				autoAddToPlatformResourceMap(project);
 				manuallyAddToPlatformResourceMap();
 				internalExecute();
@@ -246,15 +244,6 @@ public class XtextGenerator extends AbstractMojo {
 
 	public void setProjectMappings(List<ProjectMapping> projectMappings) {
 		this.projectMappings = projectMappings;
-	}
-
-	private void configureDefaults() {
-		if (sourceRoots == null) {
-			sourceRoots = Lists.newArrayList(project.getCompileSourceRoots());
-		}
-		if (javaSourceRoots == null) {
-			javaSourceRoots = Lists.newArrayList(project.getCompileSourceRoots());
-		}
 	}
 
 	/**


### PR DESCRIPTION
First the `MavenLog4JConfigurator` avoids a NPE in case the Maven logger is indeed Log4j (instead of SimpleLogger)

Second, `sourceRoots` and `javaSourceRoots` defaults are expressed directly in the @Parameter