### PR TITLE
[eclipse/xtext#1812] Use centos-7 pod template & config. JDK

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,5 +101,5 @@ pipeline {
 }
 
 def javaVersion(String version) {
-  return version.replaceAll(".*-(jdk\\d+).*", "\$1")
+  return version.replaceAll(".*-(jdk\\d+).*", "\$1").toUpperCase()
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   }
   
   tools {
-     maven "apache-maven-latest"
+     maven "apache-maven-3.6.3"
      jdk "${params.JDK_VERSION}"
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,13 @@ pipeline {
   }
 
   stages {
-    stage('Checkout') {
+    stage('Initialize') {
       steps {
         checkout scm
+        
+        script {
+          currentBuild.displayName = String.format("#%s(%s)", BUILD_NUMBER, javaVersion(JDK_VERSION))
+        }
       }
     }
 
@@ -93,5 +97,13 @@ pipeline {
         }
       }
     }
+  }
+}
+
+def javaVersion(String version) {
+  if (!version.contains('-jdk')) {
+    return 'jdk15'
+  } else {
+    return version.replaceAll(".*-(jdk\\d+).*", "\$1")
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,9 +101,5 @@ pipeline {
 }
 
 def javaVersion(String version) {
-  if (!version.contains('-jdk')) {
-    return 'jdk15'
-  } else {
-    return version.replaceAll(".*-(jdk\\d+).*", "\$1")
-  }
+  return version.replaceAll(".*-(jdk\\d+).*", "\$1")
 }


### PR DESCRIPTION
The centos-7 pod template provides a configuration suitable for most
builds. This makes the configuration of the custom container obsolete.

Additionally JDK versions are now selectable by parameter.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>