### PR TITLE
[eclipse/xtext-umbrella#223] Fix MissingPropertyExcetion in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         checkout scm
         
         script {
-          currentBuild.displayName = String.format("#%s(%s)", BUILD_NUMBER, javaVersion(JDK_VERSION))
+          currentBuild.displayName = String.format("#%s(%s)", BUILD_NUMBER, javaVersion("${params.JDK_VERSION}"))
         }
       }
     }


### PR DESCRIPTION
[eclipse/xtext-umbrella#223] Fix MissingPropertyExcetion in Jenkinsfile

Signed-off-by: Nico Prediger <mail@nicoprediger.de>