### PR TITLE
Add trace installer in "process-classes" and "process-test-classes" phases

### DIFF
--- a/org.eclipse.xtext.maven.plugin/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/pom.xml
@@ -66,6 +66,12 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.smap</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<exclusions>

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/AbstractXtextMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/AbstractXtextMojo.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.maven;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.xtext.generator.OutputConfiguration;
+
+/**
+ * @since 2.26
+ * @author Heinrich Weichert
+ *
+ */
+public abstract class AbstractXtextMojo extends AbstractMojo {
+
+	/**
+	 * Lock object to ensure thread-safety
+	 */
+	protected static final Object lock = new Object();
+
+	/**
+	 * The project itself. This parameter is set by maven.
+	 */
+	@Parameter(defaultValue = "${project}", readonly = true, required = true)
+	private MavenProject project;
+
+	@Parameter(required = true)
+	private List<Language> languages;
+
+	public MavenProject getProject() {
+		return project;
+	}
+
+	public List<Language> getLanguages() {
+		return languages;
+	}
+
+	/**
+	 * Resolves the given relative file-path to an absolute File inside the project's base directory
+	 * 
+	 * @param path Relative file path
+	 * @return File with an absolute path
+	 */
+	protected File resolveFilePath(String path) {
+		File file = new File(path);
+		if (!file.isAbsolute()) {
+			file = new File(project.getBasedir(), path);
+		}
+		return file;
+	}
+
+	protected void addCompileSourceRoots(Language language) {
+		if (language.getOutputConfigurations() == null) {
+			return;
+		}
+		for (OutputConfiguration configuration : language.getOutputConfigurations()) {
+			for (String output : configuration.getOutputDirectories()) {
+				getLog().debug("Adding output folder " + output + " to compile roots");
+				project.addCompileSourceRoot(output);
+			}
+		}
+	}
+
+	protected void addTestCompileSourceRoots(Language language) {
+		if (language.getOutputConfigurations() == null) {
+			return;
+		}
+		for (OutputConfiguration configuration : language.getOutputConfigurations()) {
+			for (String output : configuration.getOutputDirectories()) {
+				getLog().debug("Adding output folder " + output + " to test compile roots");
+				project.addTestCompileSourceRoot(output);
+			}
+		}
+	}
+
+}

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextGenerateMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextGenerateMojo.java
@@ -18,8 +18,11 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.xtext.ISetup;
 
 /**
+ * Generates sources of all contributing {@link ISetup} language instances
+ * 
  * @author Jan Rosczak - Initial contribution and API
  */
 @Mojo(name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
@@ -35,10 +38,32 @@ public class XtextGenerateMojo extends AbstractXtextGeneratorMojo {
 	public Set<String> getClasspathElements() {
 		Set<String> classpathElements = newLinkedHashSet();
 		classpathElements.addAll(this.classpathElements);
-		classpathElements.remove(project.getBuild().getOutputDirectory());
-		classpathElements.remove(project.getBuild().getTestOutputDirectory());
+		classpathElements.remove(getProject().getBuild().getOutputDirectory());
+		classpathElements.remove(getProject().getBuild().getTestOutputDirectory());
 		Set<String> nonEmptyElements = newLinkedHashSet(filter(classpathElements, emptyStringFilter()));
 		return nonEmptyElements;
 	}
+
+	@Override
+	protected void configureMavenOutputs() {
+		for (Language language : getLanguages()) {
+			addCompileSourceRoots(language);
+		}
+	}
 	
+	/**
+	 * Project source roots. List of folders, where the source models are
+	 * located.<br>
+	 * The default value is a reference to the project's
+	 * ${project.compileSourceRoots}.<br>
+	 * When adding a new entry the default value will be overwritten not extended.
+	 */
+	@Parameter(defaultValue = "${project.compileSourceRoots}", required = true)
+	private List<String> sourceRoots;
+
+	@Override
+	protected List<String> getSourceRoots() {
+		return sourceRoots;
+	}
+
 }

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextTestGenerateMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/XtextTestGenerateMojo.java
@@ -18,8 +18,11 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.xtext.ISetup;
 
 /**
+ * Generates test sources of all contributing {@link ISetup} language instances
+ * 
  * @author Jan Rosczak - Initial contribution and API
  */
 @Mojo(name = "testGenerate", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
@@ -35,8 +38,30 @@ public class XtextTestGenerateMojo extends AbstractXtextGeneratorMojo {
 	public Set<String> getClasspathElements() {
 		Set<String> classpathElementSet = newLinkedHashSet();
 		classpathElementSet.addAll(this.classpathElements);
-		classpathElementSet.remove(project.getBuild().getTestOutputDirectory());
+		classpathElementSet.remove(getProject().getBuild().getTestOutputDirectory());
 		return newLinkedHashSet(filter(classpathElementSet, emptyStringFilter()));
+	}
+
+	@Override
+	protected void configureMavenOutputs() {
+		for (Language language : getLanguages()) {
+			addTestCompileSourceRoots(language);
+		}
+	}
+	
+	/**
+	 * Project test source roots. List of folders, where the test source models are
+	 * located.<br>
+	 * The default value is a reference to the project's
+	 * ${project.testCompileSourceRoots}.<br>
+	 * When adding a new entry the default value will be overwritten not extended.
+	 */
+	@Parameter(defaultValue = "${project.testCompileSourceRoots}", required = true)
+	private List<String> sourceRoots;
+
+	@Override
+	protected List<String> getSourceRoots() {
+		return sourceRoots;
 	}
 
 }

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/AbstractInstallDebugInfoMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/AbstractInstallDebugInfoMojo.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.maven.trace;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.xtext.ISetup;
+import org.eclipse.xtext.generator.OutputConfiguration;
+import org.eclipse.xtext.generator.OutputConfigurationProvider;
+import org.eclipse.xtext.generator.trace.AbstractTraceRegion;
+import org.eclipse.xtext.generator.trace.ITraceToBytecodeInstaller;
+import org.eclipse.xtext.generator.trace.TraceAsPrimarySourceInstaller;
+import org.eclipse.xtext.generator.trace.TraceAsSmapInstaller;
+import org.eclipse.xtext.generator.trace.TraceFileNameProvider;
+import org.eclipse.xtext.generator.trace.TraceRegionSerializer;
+import org.eclipse.xtext.maven.AbstractXtextMojo;
+import org.eclipse.xtext.maven.Language;
+import org.eclipse.xtext.maven.MavenLog4JConfigurator;
+import org.eclipse.xtext.maven.MavenStandaloneBuilderModule;
+import org.eclipse.xtext.resource.FileExtensionProvider;
+
+import com.google.common.io.Files;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+/**
+ * @since 2.26
+ * @author Heinrich Weichert - initial contribution and API
+ */
+public abstract class AbstractInstallDebugInfoMojo extends AbstractXtextMojo {
+
+	@Inject
+	Provider<TraceAsPrimarySourceInstaller> traceAsPrimarySourceInstallerProvider;
+	@Inject
+	Provider<TraceAsSmapInstaller> traceAsSmapInstaller;
+	@Inject
+	TraceRegionSerializer traceRegionSerializer;
+	@Inject
+	private ClassFileDebugSourceExtractor debugSourceExtractor;
+
+	@Parameter(property = "project.basedir")
+	private File baseDirectory;
+
+	@Override
+	public void execute() throws MojoExecutionException {
+
+		synchronized (lock) {
+
+			new MavenLog4JConfigurator().configureLog4j(getLog());
+
+			Injector injector = Guice.createInjector(new MavenStandaloneBuilderModule());
+			injector.injectMembers(this);
+
+			for (Language language : getLanguages()) {
+
+				Set<OutputConfiguration> outputConfigurations = language.getOutputConfigurations();
+				if (outputConfigurations == null) {
+					getLog().warn("No output configurations available for language " + language.getSetup()
+							+ ", assuming default layout and using SMAP trace.");
+					outputConfigurations = new OutputConfigurationProvider().getOutputConfigurations();
+				}
+
+				try {
+					Class<?> setup = getClass().getClassLoader().loadClass(language.getSetup());
+					ISetup languageSetup = (ISetup) setup.getDeclaredConstructor().newInstance();
+					Injector languageInjector = languageSetup.createInjectorAndDoEMFRegistration();
+					FileExtensionProvider fileExtensionProvider = languageInjector
+							.getInstance(FileExtensionProvider.class);
+					TraceFileNameProvider traceFileNameProvider = languageInjector
+							.getInstance(TraceFileNameProvider.class);
+
+					for (OutputConfiguration config : outputConfigurations) {
+						ITraceToBytecodeInstaller traceInstaller = getTraceInstaller(config);
+						List<Trace> traces = createTraceInformation(getOutputDirectories(config),
+								traceFileNameProvider);
+						installTraces(fileExtensionProvider.getFileExtensions(), traceInstaller, traces,
+								traceFileNameProvider);
+					}
+
+				} catch (Exception e) {
+					throw new MojoExecutionException("Failed to install traces for " + language.getSetup(), e);
+				}
+			}
+		}
+	}
+
+	private Set<File> getOutputDirectories(OutputConfiguration config) {
+		return config.getOutputDirectories().stream().map(this::resolveFilePath).collect(Collectors.toSet());
+	}
+
+	protected abstract File getOutputDirectory();
+
+	private ITraceToBytecodeInstaller getTraceInstaller(OutputConfiguration config) {
+		ITraceToBytecodeInstaller bytecodeInstaller = config.isInstallDslAsPrimarySource()
+				? traceAsPrimarySourceInstallerProvider.get()
+				: traceAsSmapInstaller.get();
+		if (bytecodeInstaller instanceof TraceAsPrimarySourceInstaller) {
+			boolean hideSyntheticLocalVariables = config.isHideSyntheticLocalVariables();
+			((TraceAsPrimarySourceInstaller) bytecodeInstaller).setHideSyntheticVariables(hideSyntheticLocalVariables);
+		}
+		return bytecodeInstaller;
+	}
+
+	/**
+	 * Holds information for an {@link ITraceToBytecodeInstaller}
+	 *
+	 */
+	private class Trace {
+		File traceFile;
+		File classFile;
+	}
+
+	protected void collectTraceInformationForClassFiles(File sourceFolder, List<Trace> traces,
+			TraceFileNameProvider traceFileNameProvider) throws IOException {
+
+		File root = getOutputDirectory();
+		if (!root.exists()) {
+			getLog().info("Unable to attach trace files, output directory " + root + " does not exist");
+			return;
+		}
+
+		try (Stream<Path> walker = java.nio.file.Files.walk(root.toPath())) {
+			walker.forEach(path -> {
+				File file = path.toFile();
+				boolean isClassFile = "class".equals(Files.getFileExtension(file.getName()));
+				if (isClassFile) {
+					try {
+						String javaSourceName = debugSourceExtractor.getDebugSourceFileName(file);
+						Path relativeJavaFilePath = root.toPath().relativize(path);
+						Path srcGenRelativeFolder = sourceFolder.toPath().resolve(relativeJavaFilePath).getParent();
+						Path javaFilePath = srcGenRelativeFolder.resolve(javaSourceName);
+						if (javaFilePath.toFile().exists()) {
+							String traceFileName = traceFileNameProvider
+									.getTraceFromJava(javaFilePath.toFile().getName());
+							Path traceFilePath = srcGenRelativeFolder.resolve(traceFileName);
+							if (traceFilePath.toFile().exists()) {
+								Trace trace = new Trace();
+								trace.classFile = file;
+								trace.traceFile = traceFilePath.toFile();
+								traces.add(trace);
+							} else {
+								getLog().debug("Trace file for file " + file + "not found");
+							}
+						}
+					} catch (Exception e) {
+						getLog().error("Failed to analyze file " + file, e);
+					}
+
+				}
+			});
+		}
+	}
+
+	private List<Trace> createTraceInformation(Set<File> sourceDirectories, TraceFileNameProvider traceFileNameProvider)
+			throws IOException {
+
+		List<Trace> traces = new ArrayList<>();
+		for (File sourceDirectory : sourceDirectories) {
+			collectTraceInformationForClassFiles(sourceDirectory, traces, traceFileNameProvider);
+		}
+
+		return traces;
+	}
+
+	private void installTrace(Set<String> fileExtensions, ITraceToBytecodeInstaller traceToBytecodeInstaller,
+			Trace trace, TraceFileNameProvider traceFileNameProvider) throws IOException {
+
+		File traceFile = trace.traceFile;
+		File classFile = trace.classFile;
+
+		try (InputStream fis = new FileInputStream(traceFile); BufferedInputStream in = new BufferedInputStream(fis)) {
+
+			AbstractTraceRegion traceRegion = traceRegionSerializer.readTraceRegionFrom(in);
+			if (!isRelevantFile(fileExtensions, traceRegion)) {
+				return;
+			}
+			traceToBytecodeInstaller.setTrace(traceFileNameProvider.getJavaFromTrace(traceFile.getName()), traceRegion);
+			if (getLog().isDebugEnabled()) {
+				getLog().debug("Installing trace " + traceFile + " into:");
+			}
+			byte[] bytecodeWithTraces = traceToBytecodeInstaller.installTrace(Files.toByteArray(classFile));
+			if (bytecodeWithTraces != null) {
+				Files.write(bytecodeWithTraces, classFile);
+				if (getLog().isDebugEnabled()) {
+					getLog().debug("  " + classFile);
+				}
+			} else {
+				if (getLog().isDebugEnabled()) {
+					getLog().debug("  No trace installed for " + classFile);
+				}
+			}
+		}
+
+	}
+
+	protected void installTraces(Set<String> fileExtensions, ITraceToBytecodeInstaller traceToBytecodeInstaller,
+			List<Trace> traceToClassFileMap, TraceFileNameProvider traceFileNameProvider) {
+		for (Trace trace : traceToClassFileMap) {
+			try {
+				installTrace(fileExtensions, traceToBytecodeInstaller, trace, traceFileNameProvider);
+			} catch (Exception e) {
+				getLog().error("Error installing trace into " + trace.classFile, e);
+			}
+		}
+	}
+
+	protected boolean isRelevantFile(Set<String> fileExtensions, AbstractTraceRegion traceRegion) {
+		String fileExtension = traceRegion.getAssociatedSrcRelativePath().getURI().fileExtension();
+		return fileExtensions.contains(fileExtension);
+	}
+
+}

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/ClassFileDebugSourceExtractor.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/ClassFileDebugSourceExtractor.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.maven.trace;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
+import com.google.common.io.Files;
+
+/**
+ * @since 2.26
+ * @author Heinrich Weichert
+ */
+public class ClassFileDebugSourceExtractor {
+
+	protected static class Visitor extends ClassVisitor {
+		public Visitor() {
+			super(Opcodes.ASM9);
+		}
+
+		protected String source;
+
+		@Override
+		public void visitSource(final String source, final String debug) {
+			this.source = source;
+		}
+	}
+
+	public String getDebugSourceFileName(File classFile) throws IOException {
+		ClassReader cr = new ClassReader(Files.toByteArray(classFile));
+		Visitor visitor = new Visitor();
+		cr.accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_FRAMES);
+		return visitor.source;
+	}
+}

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/InstallDebugInfoMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/InstallDebugInfoMojo.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.maven.trace;
+
+import java.io.File;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Attaches trace (debug) information to all target classes
+ * 
+ * @since 2.26
+ * 
+ * @author Heinrich Weichert
+ */
+@Mojo(name = "install-debug-info", defaultPhase = LifecyclePhase.PROCESS_CLASSES, threadSafe = true)
+public class InstallDebugInfoMojo extends AbstractInstallDebugInfoMojo {
+
+	protected File getOutputDirectory() {
+		return resolveFilePath(getProject().getBuild().getOutputDirectory());
+	}
+	
+}

--- a/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/TestInstallDebugInfoMojo.java
+++ b/org.eclipse.xtext.maven.plugin/src/main/java/org/eclipse/xtext/maven/trace/TestInstallDebugInfoMojo.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.maven.trace;
+
+import java.io.File;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+/**
+ * Attaches trace (debug) information to all target test classes
+ * 
+ * @since 2.26
+ * 
+ * @author Heinrich Weichert
+ */
+@Mojo(name = "test-install-debug-info", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, threadSafe = true)
+public class TestInstallDebugInfoMojo extends AbstractInstallDebugInfoMojo {
+
+	protected File getOutputDirectory() {
+		return resolveFilePath(getProject().getBuild().getTestOutputDirectory());
+	}
+
+}

--- a/org.eclipse.xtext.maven.plugin/src/test/java/org/eclipse/xtext/maven/plugin/XtextGeneratorIT.java
+++ b/org.eclipse.xtext.maven.plugin/src/test/java/org/eclipse/xtext/maven/plugin/XtextGeneratorIT.java
@@ -8,6 +8,8 @@
  *******************************************************************************/
 package org.eclipse.xtext.maven.plugin;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -16,6 +18,7 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.apache.maven.it.util.ResourceExtractor;
 import org.apache.maven.shared.utils.cli.CommandLineUtils;
+import org.eclipse.xtext.maven.trace.ClassFileDebugSourceExtractor;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -66,7 +69,8 @@ public class XtextGeneratorIT {
 	@Test
 	public void mavenConfiguration() throws Exception {
 		Verifier verifier = verifyErrorFreeLog(ROOT + "/maven-config");
-		verifier.assertFileMatches(verifier.getBasedir() + "/model2-output/Model.nojdt.txt", "People to greet\\: maven2");
+		verifier.assertFileMatches(verifier.getBasedir() + "/model2-output/Model.nojdt.txt",
+				"People to greet\\: maven2");
 		verifier.assertFilePresent(verifier.getBasedir() + "/model-output/IntegrationTestXbase.java");
 	}
 
@@ -85,7 +89,7 @@ public class XtextGeneratorIT {
 		verifier.assertFilePresent(verifier.getBasedir() + "/target/xtext-temp/classes/IntegrationTestXbase.class");
 		verifier.assertFilePresent(verifier.getBasedir() + "/target/xtext-temp/classes/IntegrationTestXbase2.class");
 	}
-	
+
 	@Test
 	public void outputPerGoal() throws Exception {
 		Verifier verifier = verifyErrorFreeLog(ROOT + "/output-per-goal");
@@ -93,7 +97,7 @@ public class XtextGeneratorIT {
 		verifier.assertFilePresent(verifier.getBasedir() + "/target/xtext-temp/classes/SimpleClassXbase.class");
 		verifier.assertFilePresent(verifier.getBasedir() + "/src-test-gen/SimpleTestClassXbase.java");
 		verifier.assertFilePresent(verifier.getBasedir() + "/target/xtext-temp/classes/SimpleTestClassXbase.class");
-	}	
+	}
 
 	@Test
 	public void outputPerSource() throws Exception {
@@ -123,19 +127,19 @@ public class XtextGeneratorIT {
 
 	@Test
 	public void xcore() throws Exception {
-		Verifier verifier = verifyErrorFreeLog(ROOT + "/xcore-lang",true, "clean", "verify");
+		Verifier verifier = verifyErrorFreeLog(ROOT + "/xcore-lang", true, "clean", "verify");
 		verifier.assertFilePresent(verifier.getBasedir() + "/src-gen/org/eclipse/xcoretest/MyClass2.java");
 		verifier.assertFilePresent(
 				verifier.getBasedir() + "/target/xtext-temp/classes/org/eclipse/xcoretest/MyClass2.class");
 		verifier.assertFileMatches(verifier.getBasedir() + "/src-gen/org/eclipse/xcoretest/MyEnum.java",
 				"(?s).*MY_FIRST_LITERAL\\(-7.*MY_SECOND_LITERAL\\(137.*");
 	}
-	
+
 	@Test
 	public void xcoreMapping() throws Exception {
 		verifyErrorFreeLog(ROOT + "/xcore-mapping", true, "clean", "verify");
 	}
-	
+
 	@Test
 	public void xcoreAutoMapping() throws Exception {
 		verifyErrorFreeLog(ROOT + "/xcore-auto-mapping", true, "clean", "verify");
@@ -147,18 +151,35 @@ public class XtextGeneratorIT {
 		verifier.assertFilePresent(verifier.getBasedir() + "/src-gen/xcore/bug463946/pack/MyModel.java");
 	}
 
+	@Test
+	public void traceFileIsGenerated() throws Exception {
+		Verifier verifier = verifyErrorFreeLog(ROOT + "/trace");
+		verifier.assertFilePresent(verifier.getBasedir() + "/src-gen/IntegrationTestXbase.java");
+		verifier.assertFilePresent(verifier.getBasedir() + "/src-gen/.IntegrationTestXbase.java._trace");
+
+		String expectedSourceName = "IntegrationTestXbase.xbase";
+		File classFile = new File(verifier.getBasedir() + "/target/classes/IntegrationTestXbase.class");
+
+		assertTraceSourceFileName(expectedSourceName, classFile);
+	}
+
+	private void assertTraceSourceFileName(String expectedSourceName, File file) throws IOException {
+		String sourceName = new ClassFileDebugSourceExtractor().getDebugSourceFileName(file);
+		assertEquals("Source file name doesn't match", expectedSourceName, sourceName);
+	}
+
 	private Verifier verifyErrorFreeLog(String pathToTestProject) throws IOException, VerificationException {
 		return verifyErrorFreeLog(pathToTestProject, false, "clean", "verify");
 	}
 
 	private Verifier verifyErrorFreeLog(String pathToTestProject, boolean updateSnapshots, String... goals)
 			throws IOException, VerificationException {
-		if(goals == null || goals.length < 1) {
+		if (goals == null || goals.length < 1) {
 			throw new IllegalArgumentException("You need to pass at least one goal to verify log");
 		}
 		Verifier verifier = newVerifier(pathToTestProject);
 
-		if(updateSnapshots) {
+		if (updateSnapshots) {
 			verifier.addCliOption("-U");
 		}
 		for (String goal : goals) {

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -74,7 +74,7 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
@@ -82,7 +82,7 @@
 			<version>${xtext-version}</version>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<pluginManagement>
@@ -94,9 +94,16 @@
 					<executions>
 						<execution>
 							<id>generate</id>
-							<phase>generate-sources</phase>
 							<goals>
 								<goal>generate</goal>
+								<goal>testGenerate</goal>
+							</goals>
+						</execution>
+						<execution>
+							<id>trace</id>
+							<goals>
+								<goal>install-debug-info</goal>
+								<goal>test-install-debug-info</goal>
 							</goals>
 						</execution>
 					</executions>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/trace/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/trace/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>xtext-maven-plugin-it</artifactId>
+		<version>IT-SNAPSHOT</version>
+	</parent>
+	<artifactId>trace-test</artifactId>
+
+	<build>
+		<resources>
+			<resource>
+				<directory>src</directory>
+			</resource>
+			<resource>
+				<directory>src-gen</directory>
+			</resource>
+		</resources>
+
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.xtext</groupId>
+				<artifactId>xtext-maven-plugin</artifactId>
+				<configuration>
+					<languages>
+						<language>
+							<setup>org.eclipse.xtext.purexbase.PureXbaseStandaloneSetup</setup>
+							<outputConfigurations>
+								<outputConfiguration>
+									<installDslAsPrimarySource>true</installDslAsPrimarySource>
+									<outputDirectory>src-gen</outputDirectory>
+									<sourceMappings>
+										<sourceMapping>
+											<outputDirectory>src-gen</outputDirectory>
+											<sourceFolder>src</sourceFolder>
+										</sourceMapping>
+									</sourceMappings>
+								</outputConfiguration>
+							</outputConfigurations>
+						</language>
+					</languages>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.xtext</groupId>
+						<artifactId>org.eclipse.xtext.purexbase</artifactId>
+						<version>${xtext-version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/trace/src/IntegrationTestXbase.xbase
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/trace/src/IntegrationTestXbase.xbase
@@ -1,0 +1,2 @@
+var listOfStrings = #['a', 'b', 'c']
+listOfStrings


### PR DESCRIPTION
This PR adds the functionality to install trace information (SMAP/DSL as primary src) into the class / test class files that are produced after the Xtext Generator outputs JAVA files and the maven compiler compiles those files. 
I also refactored the type hierarchy of the existing MOJOs to reuse some MOJO parameters.

The code is mainly copied from xtext-xtend and slightly adapted to `OutputConfiguration`. Still a WIP, but perhaps someone has the time to review this. I added a test assertion in a new "trace" integration test that asserts if a trace file exists. I don't check whether trace information is really inserted into the bytecode or not. I suppose frameworks like Mockito shall not be used here? @cdietrich 